### PR TITLE
tissot: update prebuilt kernel & some vendor trick's

### DIFF
--- a/recovery/root/etc/recovery.fstab
+++ b/recovery/root/etc/recovery.fstab
@@ -2,20 +2,23 @@
 # The filesystem that contains the filesystem checker binary (typically /system) cannot
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 
-#<src>						<mnt_point>		<type>	<mnt_flags and options>						<fs_mgr_flags>
-/dev/block/bootdevice/by-name/system		/			ext4	ro,barrier=1,discard						wait,slotselect
-/dev/block/bootdevice/by-name/userdata		/data			f2fs	nosuid,nodev,noatime,discard,fsync_mode=nobarrier		wait,check,encryptable=footer,quota
-/dev/block/bootdevice/by-name/userdata		/data			ext4	nosuid,nodev,noatime,noauto_da_alloc				wait,check,encryptable=footer,quota,formattable
-/dev/block/bootdevice/by-name/persist		/mnt/vendor/persist	ext4	nosuid,nodev,noatime						wait,check
-/dev/block/bootdevice/by-name/dsp		/vendor/dsp		ext4	ro,nosuid,nodev							wait
-/dev/block/bootdevice/by-name/modem		/vendor/firmware_mnt	vfat	ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0 wait,slotselect
-/dev/block/bootdevice/by-name/misc		/misc			emmc	defaults							defaults
+#TODO: Add 'check' as fs_mgr_flags with data partition.
+# Currently we dont have e2fsck compiled. So fs check would failed.
+
+#<src>                                      <mnt_point>     <type>  <mnt_flags and options>         						        <fs_mgr_flags>
+/dev/block/bootdevice/by-name/boot           /boot           emmc    defaults                                                        defaults
+/dev/block/bootdevice/by-name/system         /               ext4    ro,barrier=1                                                    wait,slotselect
+/dev/block/bootdevice/by-name/vendor         /vendor         ext4    ro,barrier=1                                                    wait,slotselect
+/dev/block/bootdevice/by-name/userdata       /data           ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc     wait,check,encryptable=footer
+/dev/block/bootdevice/by-name/userdata       /data           f2fs    nosuid,nodev,noatime,discard,fsync_mode=nobarrier			wait,check,encryptable=footer,quota
+/dev/block/mmcblk1p1                         /sdcard         vfat    nosuid,nodev                                                    wait,voldmanaged=sdcard1:auto,noemulatedsd,encryptable=userdata
+/dev/block/bootdevice/by-name/misc           /misc           emmc    defaults                                                        defaults
+/dev/block/bootdevice/by-name/modem          /modem          vfat  	 defaults                                    				     wait,slotselect
+/dev/block/bootdevice/by-name/persist        /persist        ext4    defaults                                    				     defaults
 /dev/block/bootdevice/by-name/config		/frp			emmc	defaults							defaults
 
-/devices/platform/soc/7864900.sdhci/mmc_host*	auto			auto	defaults							wait,voldmanaged=sdcard1:auto,noemulatedsd,encryptable=userdata
-/devices/platform/soc/7000000.ssusb/7000000.dwc3/xhci-hcd.0.auto*	auto	auto	defaults							wait,voldmanaged=usb:auto
+# USB-OTG
+/devices/platform/soc/7000000.ssusb/7000000.dwc3/xhci-hcd.0.auto   /storage/usbotg    vfat    nosuid,nodev    wait,voldmanaged=usbotg:auto
 
+# ZRAM
 /dev/block/zram0                                none                    swap    defaults                                                        zramsize=536870912,max_comp_streams=8
-
-/vendor/firmware_mnt                            /firmware               none    bind								wait
-/mnt/vendor/persist                             /persist                none    bind								wait

--- a/recovery/root/etc/recovery.fstab.stock
+++ b/recovery/root/etc/recovery.fstab.stock
@@ -1,0 +1,24 @@
+# Android fstab file.
+# The filesystem that contains the filesystem checker binary (typically /system) cannot
+# specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
+
+#TODO: Add 'check' as fs_mgr_flags with data partition.
+# Currently we dont have e2fsck compiled. So fs check would failed.
+
+#<src>                                      <mnt_point>     <type>  <mnt_flags and options>         						        <fs_mgr_flags>
+/dev/block/bootdevice/by-name/boot           /boot           emmc    defaults                                                        defaults
+/dev/block/bootdevice/by-name/system         /               ext4    ro,barrier=1                                                    wait,slotselect
+/dev/block/bootdevice/by-name/vendor         /vendor         ext4    ro,barrier=1                                                    wait,slotselect
+/dev/block/bootdevice/by-name/userdata       /data           ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc     wait,check,encryptable=footer
+/dev/block/bootdevice/by-name/userdata       /data           f2fs    nosuid,nodev,noatime,discard,fsync_mode=nobarrier			wait,check,encryptable=footer,quota
+/dev/block/mmcblk1p1                         /sdcard         vfat    nosuid,nodev                                                    wait,voldmanaged=sdcard1:auto,noemulatedsd,encryptable=userdata
+/dev/block/bootdevice/by-name/misc           /misc           emmc    defaults                                                        defaults
+/dev/block/bootdevice/by-name/modem          /modem          vfat  	 defaults                                    				     wait,slotselect
+/dev/block/bootdevice/by-name/persist        /persist        ext4    defaults                                    				     defaults
+/dev/block/bootdevice/by-name/config		/frp			emmc	defaults							defaults
+
+# USB-OTG
+/devices/platform/soc/7000000.ssusb/7000000.dwc3/xhci-hcd.0.auto   /storage/usbotg    vfat    nosuid,nodev    wait,voldmanaged=usbotg:auto
+
+# ZRAM
+/dev/block/zram0                                none                    swap    defaults                                                        zramsize=536870912,max_comp_streams=8

--- a/recovery/root/etc/recovery.fstab.stock
+++ b/recovery/root/etc/recovery.fstab.stock
@@ -8,7 +8,6 @@
 #<src>                                      <mnt_point>     <type>  <mnt_flags and options>         						        <fs_mgr_flags>
 /dev/block/bootdevice/by-name/boot           /boot           emmc    defaults                                                        defaults
 /dev/block/bootdevice/by-name/system         /               ext4    ro,barrier=1                                                    wait,slotselect
-/dev/block/bootdevice/by-name/vendor         /vendor         ext4    ro,barrier=1                                                    wait,slotselect
 /dev/block/bootdevice/by-name/userdata       /data           ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc     wait,check,encryptable=footer
 /dev/block/bootdevice/by-name/userdata       /data           f2fs    nosuid,nodev,noatime,discard,fsync_mode=nobarrier			wait,check,encryptable=footer,quota
 /dev/block/mmcblk1p1                         /sdcard         vfat    nosuid,nodev                                                    wait,voldmanaged=sdcard1:auto,noemulatedsd,encryptable=userdata

--- a/recovery/root/etc/recovery.fstab.treble
+++ b/recovery/root/etc/recovery.fstab.treble
@@ -1,0 +1,24 @@
+# Android fstab file.
+# The filesystem that contains the filesystem checker binary (typically /system) cannot
+# specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
+
+#TODO: Add 'check' as fs_mgr_flags with data partition.
+# Currently we dont have e2fsck compiled. So fs check would failed.
+
+#<src>                                      <mnt_point>     <type>  <mnt_flags and options>         						        <fs_mgr_flags>
+/dev/block/bootdevice/by-name/boot           /boot           emmc    defaults                                                        defaults
+/dev/block/bootdevice/by-name/system         /               ext4    ro,barrier=1                                                    wait,slotselect
+/dev/block/bootdevice/by-name/vendor         /vendor         ext4    ro,barrier=1                                                    wait,slotselect
+/dev/block/bootdevice/by-name/userdata       /data           ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc     wait,check,encryptable=footer
+/dev/block/bootdevice/by-name/userdata       /data           f2fs    nosuid,nodev,noatime,discard,fsync_mode=nobarrier			wait,check,encryptable=footer,quota
+/dev/block/mmcblk1p1                         /sdcard         vfat    nosuid,nodev                                                    wait,voldmanaged=sdcard1:auto,noemulatedsd,encryptable=userdata
+/dev/block/bootdevice/by-name/misc           /misc           emmc    defaults                                                        defaults
+/dev/block/bootdevice/by-name/modem          /modem          vfat  	 defaults                                    				     wait,slotselect
+/dev/block/bootdevice/by-name/persist        /persist        ext4    defaults                                    				     defaults
+/dev/block/bootdevice/by-name/config		/frp			emmc	defaults							defaults
+
+# USB-OTG
+/devices/platform/soc/7000000.ssusb/7000000.dwc3/xhci-hcd.0.auto   /storage/usbotg    vfat    nosuid,nodev    wait,voldmanaged=usbotg:auto
+
+# ZRAM
+/dev/block/zram0                                none                    swap    defaults                                                        zramsize=536870912,max_comp_streams=8

--- a/recovery/root/etc/twrp.fstab
+++ b/recovery/root/etc/twrp.fstab
@@ -1,17 +1,22 @@
-# Mount point    FStype            Device                                   Flags
-/boot            emmc              /dev/block/bootdevice/by-name/boot       flags=slotselect
-/system          ext4              /dev/block/bootdevice/by-name/system     flags=slotselect
-/system_image    emmc              /dev/block/bootdevice/by-name/system     flags=slotselect
-/vendor          ext4              /dev/block/bootdevice/by-name/vendor     flags=backup=1;slotselect
-/vendor_image    emmc              /dev/block/bootdevice/by-name/vendor     flags=backup=1;slotselect
-/data            ext4              /dev/block/bootdevice/by-name/userdata   flags=encryptable=footer
+# Android fstab file.
+# The filesystem that contains the filesystem checker binary (typically /system) cannot
+# specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
+
+# mount point    fstype     device                 device2                      	  flags
+
+/boot            emmc              /dev/block/bootdevice/by-name/boot       	flags=slotselect;backup=1;flashimg=1
+/system          ext4              /dev/block/bootdevice/by-name/system     	flags=slotselect;backup=1;flashimg=1
+/system_image    emmc              /dev/block/bootdevice/by-name/system     	flags=slotselect;backup=1
+/vendor          emmc              /dev/block/bootdevice/by-name/vendor
+/data            ext4              /dev/block/bootdevice/by-name/userdata   	flags=encryptable=footer;backup=1;flashimg=1
+/persist         ext4              /dev/block/bootdevice/by-name/persist    	flags=display="Persist";flashimg=1
 /misc            emmc              /dev/block/bootdevice/by-name/misc
-/persist	 ext4	           /dev/block/bootdevice/by-name/persist    flags=display="Persist"
-/firmware        vfat              /dev/block/bootdevice/by-name/modem      flags=display="Firmware";mounttodecrypt;slotselect;fsflags=ro
+/firmware        vfat              /dev/block/bootdevice/by-name/modem          flags=display="Firmware";slotselect;backup=1;mounttodecrypt;fsflags=context=u:object_r:firmware_file:s0
 
 # EFS
-/efs1            emmc              /dev/block/bootdevice/by-name/modemst1   flags=backup=1;display=EFS
-/efs2            emmc              /dev/block/bootdevice/by-name/modemst2   flags=backup=1;subpartitionof=/efs1
+/efs1            emmc              /dev/block/bootdevice/by-name/modemst1   	flags=backup=1;display=EFS;flashimg=1
+/efs2            emmc              /dev/block/bootdevice/by-name/modemst2   	flags=backup=1;subpartitionof=/efs1;flashimg=1
 
-/sdcard1         auto              /dev/block/mmcblk1p1 /dev/block/mmcblk1  flags=display="Micro SDcard";storage;wipeingui;removable;andsec
-/usb-otg         auto              /dev/block/sda1      /dev/block/sda      flags=display="USB-OTG";storage;wipeingui;removable
+# Removable storage
+/external_sd     vfat              /dev/block/mmcblk1p1    /dev/block/mmcblk1   flags=removable;storage;display="External SD Card";wipeingui
+/usb-otg         auto              /dev/block/sda1         /dev/block/sda  		flags=removable;storage;display="USB OTG"

--- a/recovery/root/etc/twrp.fstab.stock
+++ b/recovery/root/etc/twrp.fstab.stock
@@ -9,7 +9,7 @@
 /system_image    emmc              /dev/block/bootdevice/by-name/system     	flags=slotselect;backup=1
 /vendor          emmc              /dev/block/bootdevice/by-name/vendor
 /data            ext4              /dev/block/bootdevice/by-name/userdata   	flags=encryptable=footer;backup=1;flashimg=1
-/persist         ext4              /dev/block/bootdevice/by-name/persist    	flags=display="Persist";flashimg=1
+/persist         ext4              /dev/block/bootdevice/by-name/persist    	flags=display="Persist";flashimg=1;backup=1
 /misc            emmc              /dev/block/bootdevice/by-name/misc
 /firmware        vfat              /dev/block/bootdevice/by-name/modem          flags=display="Firmware";slotselect;backup=1;mounttodecrypt;fsflags=context=u:object_r:firmware_file:s0
 

--- a/recovery/root/etc/twrp.fstab.stock
+++ b/recovery/root/etc/twrp.fstab.stock
@@ -1,0 +1,22 @@
+# Android fstab file.
+# The filesystem that contains the filesystem checker binary (typically /system) cannot
+# specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
+
+# mount point    fstype     device                 device2                      	  flags
+
+/boot            emmc              /dev/block/bootdevice/by-name/boot       	flags=slotselect;backup=1;flashimg=1
+/system          ext4              /dev/block/bootdevice/by-name/system     	flags=slotselect;backup=1;flashimg=1
+/system_image    emmc              /dev/block/bootdevice/by-name/system     	flags=slotselect;backup=1
+/vendor          emmc              /dev/block/bootdevice/by-name/vendor
+/data            ext4              /dev/block/bootdevice/by-name/userdata   	flags=encryptable=footer;backup=1;flashimg=1
+/persist         ext4              /dev/block/bootdevice/by-name/persist    	flags=display="Persist";flashimg=1
+/misc            emmc              /dev/block/bootdevice/by-name/misc
+/firmware        vfat              /dev/block/bootdevice/by-name/modem          flags=display="Firmware";slotselect;backup=1;mounttodecrypt;fsflags=context=u:object_r:firmware_file:s0
+
+# EFS
+/efs1            emmc              /dev/block/bootdevice/by-name/modemst1   	flags=backup=1;display=EFS;flashimg=1
+/efs2            emmc              /dev/block/bootdevice/by-name/modemst2   	flags=backup=1;subpartitionof=/efs1;flashimg=1
+
+# Removable storage
+/external_sd     vfat              /dev/block/mmcblk1p1    /dev/block/mmcblk1   flags=removable;storage;display="External SD Card";wipeingui
+/usb-otg         auto              /dev/block/sda1         /dev/block/sda  		flags=removable;storage;display="USB OTG"

--- a/recovery/root/etc/twrp.fstab.treble
+++ b/recovery/root/etc/twrp.fstab.treble
@@ -1,0 +1,23 @@
+# Android fstab file.
+# The filesystem that contains the filesystem checker binary (typically /system) cannot
+# specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
+
+# mount point    fstype     device                 device2                      	  flags
+
+/boot            emmc              /dev/block/bootdevice/by-name/boot       	flags=slotselect;backup=1;flashimg=1
+/system          ext4              /dev/block/bootdevice/by-name/system     	flags=slotselect;backup=1;flashimg=1
+/system_image    emmc              /dev/block/bootdevice/by-name/system     	flags=slotselect;backup=1
+/vendor          ext4              /dev/block/bootdevice/by-name/vendor     	flags=slotselect;display="Vendor";backup=1;flashimg=1;wipeingui;
+/vendor_image    emmc              /dev/block/bootdevice/by-name/vendor     	flags=slotselect;backup=1
+/data            ext4              /dev/block/bootdevice/by-name/userdata   	flags=encryptable=footer;backup=1;flashimg=1
+/persist         ext4              /dev/block/bootdevice/by-name/persist    	flags=display="Persist";flashimg=1
+/misc            emmc              /dev/block/bootdevice/by-name/misc
+/firmware        vfat              /dev/block/bootdevice/by-name/modem          flags=display="Firmware";slotselect;backup=1;mounttodecrypt;fsflags=context=u:object_r:firmware_file:s0
+
+# EFS
+/efs1            emmc              /dev/block/bootdevice/by-name/modemst1   	flags=backup=1;display=EFS;flashimg=1
+/efs2            emmc              /dev/block/bootdevice/by-name/modemst2   	flags=backup=1;subpartitionof=/efs1;flashimg=1
+
+# Removable storage
+/external_sd     vfat              /dev/block/mmcblk1p1    /dev/block/mmcblk1   flags=removable;storage;display="External SD Card";wipeingui
+/usb-otg         auto              /dev/block/sda1         /dev/block/sda  		flags=removable;storage;display="USB OTG"

--- a/recovery/root/etc/twrp.fstab.treble
+++ b/recovery/root/etc/twrp.fstab.treble
@@ -10,7 +10,7 @@
 /vendor          ext4              /dev/block/bootdevice/by-name/vendor     	flags=slotselect;display="Vendor";backup=1;flashimg=1;wipeingui;
 /vendor_image    emmc              /dev/block/bootdevice/by-name/vendor     	flags=slotselect;backup=1
 /data            ext4              /dev/block/bootdevice/by-name/userdata   	flags=encryptable=footer;backup=1;flashimg=1
-/persist         ext4              /dev/block/bootdevice/by-name/persist    	flags=display="Persist";flashimg=1
+/persist         ext4              /dev/block/bootdevice/by-name/persist    	flags=display="Persist";flashimg=1;backup=1
 /misc            emmc              /dev/block/bootdevice/by-name/misc
 /firmware        vfat              /dev/block/bootdevice/by-name/modem          flags=display="Firmware";slotselect;backup=1;mounttodecrypt;fsflags=context=u:object_r:firmware_file:s0
 

--- a/recovery/root/init.recovery.service.rc
+++ b/recovery/root/init.recovery.service.rc
@@ -1,0 +1,5 @@
+on boot
+
+# For starting recovery on 5.0 and newer
+service recovery /sbin/recovery.sh
+    seclabel u:r:recovery:s0

--- a/recovery/root/sbin/recovery.sh
+++ b/recovery/root/sbin/recovery.sh
@@ -1,0 +1,43 @@
+#!/sbin/sh
+
+### Recovery service bootstrap for better Treble support
+# Purpose:
+#  - Prevent recovery from being restarted when it's killed (equivalent to a one-shot service)
+#  - symlink to the correct fstab depending on Treble partition state
+
+# vendor_b partition info
+vendor_b_partnum=51
+vendor_b_partstart_system=12539904
+vendor_b_partend_system=13768703
+vendor_b_partstart_userdata=15778834
+vendor_b_partend_userdata=17007633
+vendor_b_blockdev=/dev/block/mmcblk0p51
+
+# vendor_a partition info
+vendor_a_partnum=50
+vendor_a_partstart_system=6248448
+vendor_a_partend_system=7477247
+vendor_a_partstart_userdata=14550032
+vendor_a_partend_userdata=15778832
+vendor_a_blockdev=/dev/block/mmcblk0p50
+
+# check mount situation and use appropriate fstab
+rm /etc/twrp.fstab
+rm /etc/recovery.fstab
+
+if [ -b "$vendor_a_blockdev" -a -b "$vendor_b_blockdev" ]; then
+	ln -sn /etc/twrp.fstab.treble /etc/twrp.fstab
+        ln -sn /etc/recovery.fstab.treble  /etc/recovery.fstab
+else
+	ln -sn /etc/twrp.fstab.stock /etc/twrp.fstab
+        ln -sn /etc/recovery.fstab.stock  /etc/recovery.fstab
+fi;
+
+# start recovery
+/sbin/recovery &
+
+# idle around
+while kill -0 `pidof recovery`; do sleep 1; done
+
+# stop self
+stop recovery


### PR DESCRIPTION
- kernel updated to 4.9.258 (fixing ft8716 black display issue in fastboot version)
[Murtaza@Piplod kernel](https://github.com/MASTERGUY/android_kernel_xiaomi_msm8953/tree/fdf1fec8a61a10d90054b5ea6eaaf1ec802a964b)
[FT8716 display specific commit]
(https://github.com/MASTERGUY/android_kernel_xiaomi_msm8953/commit/294fa3339e117b861e7650849192b9be64f24360)
- Modify recovery.service.rc (run recovery.sh before it start twrp) based on CosmicDan's recovery.
[Link to CosmicDan's script template](https://github.com/CosmicDan-Android/android_device_xiaomi_tissot/blob/8.1-treble/recovery/root/sbin/recovery.sh)
recovery.sh script check partition layout situation, symlinking to proper fstab, then start main recovery service.
That's need to avoid errors like "Cannot mount /vendor" or "unable to find partition for path /vendor" and etc, if device on stock partition layout 